### PR TITLE
fix: get theme config from the ds config file

### DIFF
--- a/apps/linkedin-to-notion/tailwind.config.js
+++ b/apps/linkedin-to-notion/tailwind.config.js
@@ -1,7 +1,10 @@
+const designSystemConfig = require('../../libs/design-system/tailwind.config.js');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   mode: 'jit',
   darkMode: 'class',
+  theme: designSystemConfig.theme,
   content: ['./**/*.tsx'],
   plugins: [],
 };


### PR DESCRIPTION
# Context

See [Notion](https://www.notion.so/bvelitchkine/Align-tailwind-config-across-the-monorepo-7126132eec0646cdba063dce9a3792a7?pvs=4)

# Solution

Got largely inspired by what I saw here: https://dev.to/bdbch/sharing-your-tailwind-configuration-between-monorepo-packages-4o5k

# Priority

High
