### PR TITLE
🐛 fix(infra) PLAS-32: pass the eslint settings from the monorepo to the design system

### DIFF
--- a/libs/design-system/.eslintrc.cjs
+++ b/libs/design-system/.eslintrc.cjs
@@ -1,14 +1,11 @@
 module.exports = {
   root: true,
   env: { browser: true, es2020: true },
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'plugin:storybook/recommended'],
+  extends: ['../../.eslintrc.js'],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
   rules: {
-    'react-refresh/only-export-components': [
-      'warn',
-      { allowConstantExport: true },
-    ],
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
   },
-}
+};


### PR DESCRIPTION
# Context

Simply make sure the settings of the linter is consistent across the repo and in the design system.

# Priority

High
