### PR TITLE
✨ feat(back) PLAS-23: create linkedin profile scraper

### DIFF
--- a/apps/linkedin-to-notion/src/contents/linkedin-data-cleaners.ts
+++ b/apps/linkedin-to-notion/src/contents/linkedin-data-cleaners.ts
@@ -12,7 +12,7 @@ export const splitName = (fullName: string): { firstName?: string; lastName?: st
   }
   return {
     firstName: names[0].trim(),
-    lastName: names.slice(1).join(" ").trim(),
+    lastName: names.slice(1).join(' ').trim(),
   };
 };
 

--- a/apps/linkedin-to-notion/src/contents/linkedin-data-cleaners.ts
+++ b/apps/linkedin-to-notion/src/contents/linkedin-data-cleaners.ts
@@ -1,0 +1,26 @@
+/**
+ * Basic function to split first and last name in common case ie. they are split by a space
+ * @param fullName Full name eg. 'Gauvain Thery'
+ * @returns an object with a split between first and last names
+ */
+export const splitName = (fullName: string): { firstName?: string; lastName?: string } => {
+  const names = fullName.split(' ');
+  if (names.length === 1) {
+    return {
+      firstName: names[0],
+    };
+  }
+  return {
+    firstName: names[0].trim(),
+    lastName: names[names.length - 1].trim(),
+  };
+};
+
+/**
+ * Basic function to remove unwanted elements from linkedin job titles
+ * @param jobTitle The raw job title from linkedIn
+ * @returns a clean job title
+ */
+export const cleanJobTitle = (jobTitle: string): string => {
+  return jobTitle.split(/ at| @| chez/g)[0].trim();
+};

--- a/apps/linkedin-to-notion/src/contents/linkedin-data-cleaners.ts
+++ b/apps/linkedin-to-notion/src/contents/linkedin-data-cleaners.ts
@@ -12,7 +12,7 @@ export const splitName = (fullName: string): { firstName?: string; lastName?: st
   }
   return {
     firstName: names[0].trim(),
-    lastName: names[names.length - 1].trim(),
+    lastName: names.slice(1).join(" ").trim(),
   };
 };
 

--- a/apps/linkedin-to-notion/src/contents/linkedin-profile-scraper.ts
+++ b/apps/linkedin-to-notion/src/contents/linkedin-profile-scraper.ts
@@ -4,6 +4,7 @@ import { cleanJobTitle, splitName } from './linkedin-data-cleaners';
 
 export const config: PlasmoCSConfig = {
   matches: ['https://www.linkedin.com/in/*'],
+  run_at: 'document_idle',
 };
 
 type LinkedInProfileInformation = {
@@ -46,24 +47,31 @@ const getName = (): {
 };
 
 const getJobTitle = (): string => {
+  const fallbackCurrentJob = cleanJobTitle(document.querySelector('div.text-body-medium.break-words')?.textContent);
+
   const experienceAnchor = document.getElementById('experience');
   if (!experienceAnchor) {
-    return '';
+    return fallbackCurrentJob ?? '';
   }
 
   const experienceList = experienceAnchor.parentElement;
   if (!experienceList) {
-    return '';
+    return fallbackCurrentJob ?? '';
   }
 
   const lastJob = experienceList.querySelector('li');
   if (!lastJob) {
-    return '';
+    return fallbackCurrentJob ?? '';
   }
 
   const jobTitle = lastJob.querySelector('div.display-flex.align-items-center.mr1.t-bold > span');
   if (!jobTitle) {
-    return '';
+    return fallbackCurrentJob ?? '';
+  }
+
+  // This covers the case of a person with several experiences in a same company
+  if (jobTitle.textContent === getCurrentCompany()) {
+    return fallbackCurrentJob;
   }
 
   return cleanJobTitle(jobTitle.textContent);

--- a/apps/linkedin-to-notion/src/contents/linkedin-profile-scraper.ts
+++ b/apps/linkedin-to-notion/src/contents/linkedin-profile-scraper.ts
@@ -1,0 +1,126 @@
+import type { PlasmoCSConfig } from 'plasmo';
+
+import { cleanJobTitle, splitName } from './linkedin-data-cleaners';
+
+export const config: PlasmoCSConfig = {
+  matches: ['https://www.linkedin.com/in/*'],
+};
+
+type LinkedInProfileInformation = {
+  name: {
+    firstName: string;
+    lastName: string;
+  };
+  jobTitle: string;
+  currentCompany: string;
+  location: string;
+  linkedInURL: string;
+};
+
+const getName = (): {
+  firstName?: string;
+  lastName?: string;
+  fullName: string;
+} => {
+  const detailsContainer = document.querySelector('.pv-text-details__left-panel');
+  if (!detailsContainer) {
+    return {
+      fullName: '',
+    };
+  }
+
+  const name = detailsContainer.querySelector('h1.text-heading-xlarge');
+  if (!name) {
+    return {
+      fullName: '',
+    };
+  }
+
+  const { firstName, lastName } = splitName(name.textContent);
+
+  return {
+    fullName: name.textContent,
+    firstName,
+    lastName,
+  };
+};
+
+const getJobTitle = (): string => {
+  const experienceAnchor = document.getElementById('experience');
+  if (!experienceAnchor) {
+    return '';
+  }
+
+  const experienceList = experienceAnchor.parentElement;
+  if (!experienceList) {
+    return '';
+  }
+
+  const lastJob = experienceList.querySelector('li');
+  if (!lastJob) {
+    return '';
+  }
+
+  const jobTitle = lastJob.querySelector('div.display-flex.align-items-center.mr1.t-bold > span');
+  if (!jobTitle) {
+    return '';
+  }
+
+  return cleanJobTitle(jobTitle.textContent);
+};
+
+const getCurrentCompany = (): string => {
+  const detailsContainer = document.querySelector('.pv-text-details__right-panel');
+  if (!detailsContainer) {
+    return '';
+  }
+
+  const company = detailsContainer.querySelector('button.pv-text-details__right-panel-item-link > span');
+  if (!company) {
+    return '';
+  }
+
+  return company.textContent.trim();
+};
+
+const getLocation = (): string => {
+  const detailsContainer = document.querySelector('.pv-text-details__left-panel.mt2');
+  if (!detailsContainer) {
+    return '';
+  }
+
+  const location = detailsContainer.querySelector('span.text-body-small.inline.t-black--light.break-words');
+  if (!location) {
+    return '';
+  }
+
+  return location.textContent.trim();
+};
+
+export const getLinkedInProfileInformation = (): LinkedInProfileInformation => {
+  const { firstName, lastName, fullName } = getName();
+  const jobTitle = getJobTitle();
+  const currentCompany = getCurrentCompany();
+  const location = getLocation();
+  const linkedInURL = window.location.href;
+
+  return {
+    name: {
+      firstName: firstName || fullName,
+      lastName: lastName,
+    },
+    jobTitle,
+    currentCompany,
+    location,
+    linkedInURL,
+  };
+};
+
+// Keeping these lines to test the script as the front isn't yet implemented. To remove in PLAS-20: https://www.notion.so/bvelitchkine/Integrate-the-form-on-the-side-panel-af97bf09aa6346469c57bd0269751554?pvs=4
+window.addEventListener('load', () => {
+  // Adding a timeout as I'm still having issues to detect a proper load - must be resolved when using getLinkedInProfileInformation but not here
+  setTimeout(() => {
+    const LinkedInProfileInformation = getLinkedInProfileInformation();
+    console.log('🔥 ・ LinkedInProfileInformation:', LinkedInProfileInformation);
+  }, 5000);
+});


### PR DESCRIPTION
# Context

Re-creating what is called LinkedIn parser on the original project. This is only for LinkedIn, there's a dedicated issue for SalesNav. This is only the scraper, the way it'll be called is yet to be built when integrating the form.

# Solution

There's a challenge here for maintainability as LinkedIn is likely to change the structure of the front page. I tried to query elements 1 by 1 and return an empty string if not found. I created a dedicated file for data cleaning.

Also, this could have been a class but I think we'll be more efficient developing with functions and the complexity of the project is rather low so I kept things as simple as possible.

# Priority

High
