### PR TITLE
✨feat(front) PLAS-15: Text Components in Design System

### DIFF
--- a/libs/design-system/src/atoms/index.ts
+++ b/libs/design-system/src/atoms/index.ts
@@ -1,1 +1,2 @@
 export * from './titles';
+export * from './typography';

--- a/libs/design-system/src/atoms/typography/baseText.stories.tsx
+++ b/libs/design-system/src/atoms/typography/baseText.stories.tsx
@@ -18,15 +18,17 @@ export const CommonParagraph: StoryFn = () => (
     This is a <em>base</em> paragraph. We can say a variety of stuff in there, it just has to look normal.
   </BaseParagraph>
 );
+
 export const DescriptionParagraph: StoryFn = () => (
   <SmallParagraph alignment="center">
     This is a <em>small</em> paragraph. We can say a variety of stuff in there, it just has to look small. It can be the
-    description of an image for instance
+    description of an image for instance.
   </SmallParagraph>
 );
+
 export const HeroParagraph: StoryFn = () => (
   <LargeParagraph alignment="center">
-    This is a <em>large</em> paragraph. We can say a variety of stuff in there, but it's typically stuff that we don't
-    want readers to miss.
+    This is a <em>large</em> paragraph. We can say a variety of stuff in there, but it&apos;s typically stuff that we
+    don&apos;t want readers to miss.
   </LargeParagraph>
 );

--- a/libs/design-system/src/atoms/typography/baseText.stories.tsx
+++ b/libs/design-system/src/atoms/typography/baseText.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { BaseParagraph, LargeParagraph, SmallParagraph } from '.';
 
 const meta = {
-  title: 'Example/Paragraphs',
+  title: 'Atoms/Paragraphs',
   component: BaseParagraph,
   parameters: {
     layout: 'centered',

--- a/libs/design-system/src/atoms/typography/baseText.stories.tsx
+++ b/libs/design-system/src/atoms/typography/baseText.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryFn } from '@storybook/react';
+
+import { BaseParagraph, LargeParagraph, SmallParagraph } from '.';
+
+const meta = {
+  title: 'Example/Paragraphs',
+  component: BaseParagraph,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof BaseParagraph>;
+
+export default meta;
+
+export const CommonParagraph: StoryFn = () => (
+  <BaseParagraph alignment="center">
+    This is a <em>base</em> paragraph. We can say a variety of stuff in there, it just has to look normal.
+  </BaseParagraph>
+);
+export const DescriptionParagraph: StoryFn = () => (
+  <SmallParagraph alignment="center">
+    This is a <em>small</em> paragraph. We can say a variety of stuff in there, it just has to look small. It can be the
+    description of an image for instance
+  </SmallParagraph>
+);
+export const HeroParagraph: StoryFn = () => (
+  <LargeParagraph alignment="center">
+    This is a <em>large</em> paragraph. We can say a variety of stuff in there, but it's typically stuff that we don't
+    want readers to miss.
+  </LargeParagraph>
+);

--- a/libs/design-system/src/atoms/typography/baseText.tsx
+++ b/libs/design-system/src/atoms/typography/baseText.tsx
@@ -1,0 +1,32 @@
+import { cn } from '../../shared/classnames';
+
+type ParagraphProps = {
+  type?: 'sm' | 'base' | 'lg';
+  alignment?: 'left' | 'center' | 'right';
+  className?: string;
+  children: React.ReactNode;
+};
+
+const fontSizeMapping = {
+  sm: 'text-3.5',
+  base: 'text-4',
+  lg: 'text-5',
+};
+
+const aligmentMapping = {
+  left: 'text-left',
+  center: 'text-center',
+  right: 'text-right',
+};
+
+const Paragraph = ({ type = 'base', alignment = 'left', className, children }: ParagraphProps) => {
+  return (
+    <p className={cn('antialiased', 'text-gray', fontSizeMapping[type], aligmentMapping[alignment], className)}>
+      {children}
+    </p>
+  );
+};
+
+export const SmallParagraph = (p: Omit<ParagraphProps, 'type'>) => <Paragraph type="sm" {...p} />;
+export const BaseParagraph = (p: Omit<ParagraphProps, 'type'>) => <Paragraph type="base" {...p} />;
+export const LargeParagraph = (p: Omit<ParagraphProps, 'type'>) => <Paragraph type="lg" {...p} />;

--- a/libs/design-system/src/atoms/typography/baseText.tsx
+++ b/libs/design-system/src/atoms/typography/baseText.tsx
@@ -13,7 +13,7 @@ const fontSizeMapping = {
   lg: 'text-5',
 };
 
-const aligmentMapping = {
+const alignmentMapping = {
   left: 'text-left',
   center: 'text-center',
   right: 'text-right',
@@ -21,7 +21,7 @@ const aligmentMapping = {
 
 const Paragraph = ({ type = 'base', alignment = 'left', className, children }: ParagraphProps) => {
   return (
-    <p className={cn('antialiased', 'text-gray', fontSizeMapping[type], aligmentMapping[alignment], className)}>
+    <p className={cn('antialiased', 'text-gray', fontSizeMapping[type], alignmentMapping[alignment], className)}>
       {children}
     </p>
   );

--- a/libs/design-system/src/atoms/typography/index.ts
+++ b/libs/design-system/src/atoms/typography/index.ts
@@ -1,0 +1,1 @@
+export * from './baseText';


### PR DESCRIPTION
# Context

In the process of reproducing the original extension, we might need some text paragraphs here and there.

# Solution

Three different types of text paragraphs. The only thing that changes is the **font size**.

### Side Note
You'll see some `<em>` tags here and there: it's just to make sure that HTML could properly be passed as children, and not solely strings.
