### PR TITLE
✨ feat(front) PLAS-35: Sales Navigator Profile Scraper

### DIFF
--- a/apps/linkedin-to-notion/src/contents/salesnav-profile-scraper.ts
+++ b/apps/linkedin-to-notion/src/contents/salesnav-profile-scraper.ts
@@ -1,0 +1,117 @@
+import type { PlasmoCSConfig } from 'plasmo';
+
+import { cleanJobTitle, splitName } from './linkedin-data-cleaners';
+
+export const config: PlasmoCSConfig = {
+  matches: ['https://www.linkedin.com/sales/people/*'],
+  run_at: 'document_idle',
+};
+
+type SalesNavProfileInformation = {
+  name: {
+    firstName: string;
+    lastName: string;
+  };
+  jobTitle: string;
+  currentCompany: string;
+  location: string;
+  salesNavURL: string;
+};
+
+const getName = (): {
+  firstName?: string;
+  lastName?: string;
+  fullName: string;
+} => {
+  const name = document.querySelector("span[data-anonymize='person-name']");
+  if (!name) {
+    return {
+      fullName: '',
+    };
+  }
+
+  const { firstName, lastName } = splitName(name.textContent);
+
+  return {
+    fullName: name.textContent.trim(),
+    firstName,
+    lastName,
+  };
+};
+
+const getJobTitle = (): string => {
+  const headline = cleanJobTitle(document.querySelector("dd[data-anonymize='headline']")?.textContent);
+
+  const hasJobAnchor = document.querySelector('button span.artdeco-button__text');
+  if (!hasJobAnchor) {
+    return headline ?? '';
+  }
+
+  const hasJob = hasJobAnchor.textContent.trim().match('Actuel');
+  if (!hasJob) {
+    return headline ?? '';
+  }
+
+  const jobTitle = document.querySelector("span[data-anonymize='job-title']");
+  if (!jobTitle) {
+    return headline ?? '';
+  }
+
+  return cleanJobTitle(jobTitle.textContent);
+};
+
+const getCurrentCompany = (): string => {
+  const hasJobAnchor = document.querySelector('button span.artdeco-button__text');
+  if (!hasJobAnchor) {
+    return '';
+  }
+
+  const hasJob = hasJobAnchor.textContent.trim().match('Actuel');
+  if (!hasJob) {
+    return '';
+  }
+
+  const companyAnchor = document.querySelector("a[data-anonymize='company-name']");
+  if (!companyAnchor) {
+    return '';
+  }
+
+  return companyAnchor.textContent.trim();
+};
+
+const getLocation = (): string => {
+  const locationAnchor = document.querySelector("div[data-anonymize='location']");
+  if (!locationAnchor) {
+    return '';
+  }
+
+  return locationAnchor.textContent.trim();
+};
+
+export const getSalesNavProfileInformation = (): SalesNavProfileInformation => {
+  const { firstName, lastName, fullName } = getName();
+  const jobTitle = getJobTitle();
+  const currentCompany = getCurrentCompany();
+  const location = getLocation();
+  const salesNavURL = window.location.href;
+
+  return {
+    name: {
+      firstName: firstName || fullName,
+      lastName: lastName,
+    },
+    jobTitle,
+    currentCompany,
+    location,
+    salesNavURL,
+  };
+};
+
+// Keeping these lines to test the script as the front isn't yet implemented. To remove in PLAS-20: https://www.notion.so/bvelitchkine/Integrate-the-form-on-the-side-panel-af97bf09aa6346469c57bd0269751554?pvs=4
+window.addEventListener('load', () => {
+  // Adding a timeout as I'm still having issues to detect a proper load - must be resolved when using getLinkedInProfileInformation but not here
+  setTimeout(() => {
+    const salesNavProfileInformation = getSalesNavProfileInformation();
+    console.log('🔥 ・ LinkedInProfileInformation:', salesNavProfileInformation);
+  }, 5000);
+});


### PR DESCRIPTION
# Context

The LinkedIn profile scraper had already been coded. I used the related files as templates.

# Caveats

- I can't test the scraper as I don't have a Sales Navigator license anymore lmao
- In the final payload I return a `salesNavURL`, not a `linkedinURL`.

> Why make a difference btw SalesNav URLs and LinkedIn URLs?

**For duplicates detection**:
- Even if you have a sales navigator license, you might sometimes jump to LinkedIn. Sales Nav URLs and LinkedIn URLs are always different. So, if you have both in a same Notion database, it hints that we should be more thorough when looking for duplicates and not only compare URLs.
- Same for Twitter. If our mission is to help freelance recruiters make more cash, there's no reason to stop at LinkedIn, Sales Navigator and LinkedIn Recruiter. A sourcer goes on all sorts of platforms. And since someone can have profiles on all of these platforms, it also hints that, at some point, we'll have to revamp our deduplication process.

> We can't test it on Sales Nav, we're not gonna roll that out are we?

I agree. Let's have the file there as a reminder but let's not say publicly that we support anything else than classic LinkedIn. If it happens to work on SN, great, but that's it. **What do you think?**