### PR TITLE
🎨 improvement(front) PLAS-047: Handle 'Go Back' in LinkedIn

### DIFF
--- a/apps/linkedin-to-notion/src/background/index.ts
+++ b/apps/linkedin-to-notion/src/background/index.ts
@@ -9,7 +9,7 @@ chrome.action.onClicked.addListener((tab) => {
 });
 
 chrome.tabs.onUpdated.addListener((tabId, { status }, tab) => {
-  if (tab.url?.match(linkedInURLRegex)) {
+  if (tab.url && tab.url.match(linkedInURLRegex)) {
     if (status === 'complete') {
       chrome.tabs.sendMessage(tabId, 'updateLinkedInNotionSidePanel');
     }

--- a/apps/linkedin-to-notion/src/background/index.ts
+++ b/apps/linkedin-to-notion/src/background/index.ts
@@ -2,18 +2,18 @@ export {};
 
 const linkedInURLRegex = /linkedin.com\/in\/.+/;
 
-chrome.action.onClicked.addListener((tab) => {
+chrome.action.onClicked.addListener(async (tab) => {
   if (tab.url.match(linkedInURLRegex)) {
-    chrome.tabs.sendMessage(tab.id, 'toggleLinkedInNotionSidePanel');
+    return await chrome.tabs.sendMessage(tab.id, 'toggleLinkedInNotionSidePanel');
   }
 });
 
-chrome.tabs.onUpdated.addListener((tabId, { status }, tab) => {
+chrome.tabs.onUpdated.addListener(async (tabId, { status }, tab) => {
   if (tab.url && tab.url.match(linkedInURLRegex)) {
     if (status === 'complete') {
-      chrome.tabs.sendMessage(tabId, 'updateLinkedInNotionSidePanel');
+      return await chrome.tabs.sendMessage(tabId, 'updateLinkedInNotionSidePanel');
     }
   } else {
-    chrome.tabs.sendMessage(tabId, 'closeLinkedInNotionSidePanel');
+    return await chrome.tabs.sendMessage(tabId, 'closeLinkedInNotionSidePanel');
   }
 });

--- a/apps/linkedin-to-notion/src/background/index.ts
+++ b/apps/linkedin-to-notion/src/background/index.ts
@@ -8,9 +8,12 @@ chrome.action.onClicked.addListener((tab) => {
   }
 });
 
-chrome.tabs.onUpdated.addListener((tabId, _, tab) => {
-  if (tab.url.match(linkedInURLRegex)) {
-    return chrome.tabs.sendMessage(tabId, 'updateLinkedInNotionSidePanel');
+chrome.tabs.onUpdated.addListener((tabId, { status }, tab) => {
+  if (tab.url?.match(linkedInURLRegex)) {
+    if (status === 'complete') {
+      chrome.tabs.sendMessage(tabId, 'updateLinkedInNotionSidePanel');
+    }
+  } else {
+    chrome.tabs.sendMessage(tabId, 'closeLinkedInNotionSidePanel');
   }
-  return chrome.tabs.sendMessage(tabId, 'closeLinkedInNotionSidePanel');
 });

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
@@ -39,7 +39,8 @@ export const LinkedInNotionSidePanelContent = ({
   chrome.runtime.onMessage.addListener((msg) => {
     if (msg === 'updateLinkedInNotionSidePanel') {
       setLinkedInProfileInformation(null);
-      injectLinkedInInformation();
+      // We set a timeout to wait for the page to be fully loaded before attempting to scrape the information
+      setTimeout(() => injectLinkedInInformation(), 2000);
     }
   });
 

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
@@ -39,7 +39,8 @@ export const LinkedInNotionSidePanelContent = ({
   chrome.runtime.onMessage.addListener((msg) => {
     if (msg === 'updateLinkedInNotionSidePanel') {
       setLinkedInProfileInformation(null);
-      // We set a timeout to wait for the page to be fully loaded before attempting to scrape the information
+      // TODO: find a more robust alternative than a timeout
+      // Couldn't put the timeout in the bg (don't know why)
       setTimeout(() => injectLinkedInInformation(), 2000);
     }
   });


### PR DESCRIPTION
# Problem
![image](https://github.com/Bastien-and-Gauvain/monorepo/assets/45038783/c9a0bb2e-6ef8-4365-9cbb-c5e93b7a8cbf)
Here's what used to happen:
1. We'd visit a first profile on LinkedIn
2. The data would be scraped and fill the extension fields
3. We'd visit another profile on LinkedIn
4. The data would - once again - be scraped and fill the extension fields.
5. Then we'd click on 'go back' in the browser to roll back to the first profile (cf. pink highlight on screenshot above)
6. Its data would **not be scraped**

# Solution
It's not the cleanest of solutions but it's the only one I found: a mere `setTimeout` of 2s... Anyway, that works seemlessly.