### PR TITLE
✨ feat(front) PLAS-018: 'Go Back To LinkedIn' CTA

### DIFF
--- a/apps/linkedin-to-notion/src/background/index.ts
+++ b/apps/linkedin-to-notion/src/background/index.ts
@@ -2,23 +2,23 @@ export {};
 
 const linkedInURLRegex = /linkedin.com\/in\/.+/;
 
-chrome.action.onClicked.addListener((tab) => {
+chrome.action.onClicked.addListener(async (tab) => {
   if (tab.url.match(linkedInURLRegex)) {
-    chrome.tabs.sendMessage(tab.id, 'toggleLinkedInNotionSidePanel');
+    return await chrome.tabs.sendMessage(tab.id, 'toggleLinkedInNotionSidePanel');
   } else {
-    chrome.tabs.sendMessage(tab.id, 'toggleGoBackToLinkedInSidePanel');
+    return await chrome.tabs.sendMessage(tab.id, 'toggleGoBackToLinkedInSidePanel');
   }
 });
 
-chrome.tabs.onUpdated.addListener((tabId, _, tab) => {
+chrome.tabs.onUpdated.addListener(async (tabId, _, tab) => {
   if (tab.url.match(linkedInURLRegex)) {
-    return chrome.tabs.sendMessage(tabId, 'updateLinkedInNotionSidePanel');
+    return await chrome.tabs.sendMessage(tabId, 'updateLinkedInNotionSidePanel');
   }
-  return chrome.tabs.sendMessage(tabId, 'closeSidePanels');
+  return await chrome.tabs.sendMessage(tabId, 'closeSidePanels');
 });
 
-chrome.runtime.onMessage.addListener((msg) => {
+chrome.runtime.onMessage.addListener(async (msg) => {
   if (msg === 'openLinkedInTab') {
-    chrome.tabs.create({ url: 'https://www.linkedin.com/in/me/' });
+    return await chrome.tabs.create({ url: 'https://www.linkedin.com/in/me/' });
   }
 });

--- a/apps/linkedin-to-notion/src/background/index.ts
+++ b/apps/linkedin-to-notion/src/background/index.ts
@@ -5,6 +5,8 @@ const linkedInURLRegex = /linkedin.com\/in\/.+/;
 chrome.action.onClicked.addListener((tab) => {
   if (tab.url.match(linkedInURLRegex)) {
     chrome.tabs.sendMessage(tab.id, 'toggleLinkedInNotionSidePanel');
+  } else {
+    chrome.tabs.sendMessage(tab.id, 'toggleGoBackToLinkedInSidePanel');
   }
 });
 
@@ -12,5 +14,11 @@ chrome.tabs.onUpdated.addListener((tabId, _, tab) => {
   if (tab.url.match(linkedInURLRegex)) {
     return chrome.tabs.sendMessage(tabId, 'updateLinkedInNotionSidePanel');
   }
-  return chrome.tabs.sendMessage(tabId, 'closeLinkedInNotionSidePanel');
+  return chrome.tabs.sendMessage(tabId, 'closeSidePanels');
+});
+
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg === 'openLinkedInTab') {
+    chrome.tabs.create({ url: 'https://www.linkedin.com/in/me/' });
+  }
 });

--- a/apps/linkedin-to-notion/src/components/GoBackToLinkedIn/GoBackToLinkedIn.tsx
+++ b/apps/linkedin-to-notion/src/components/GoBackToLinkedIn/GoBackToLinkedIn.tsx
@@ -33,7 +33,7 @@ export const GoBackToLinkedInContent = ({
       id={id}
       className="top-48 space-y-4 flex flex-col">
       <div className="flex flex-col items-center">
-        <img src={logo} className="w-12" />
+        <img src={logo} className="w-12 mb-4" />
         <ButtonPrimary onClick={askToOpenLinkedInTab}>Go Back To Linkedin</ButtonPrimary>
       </div>
     </IFramedSidePanel>

--- a/apps/linkedin-to-notion/src/components/GoBackToLinkedIn/GoBackToLinkedIn.tsx
+++ b/apps/linkedin-to-notion/src/components/GoBackToLinkedIn/GoBackToLinkedIn.tsx
@@ -1,0 +1,41 @@
+import logo from 'data-base64:~assets/icon.png';
+import cssText from 'data-text:~style.css';
+import { ButtonPrimary, IFramedSidePanel } from 'design-system';
+import { createElement } from 'react';
+
+import './../../../style.css'; // for the font to load
+
+export const getIFrameStyle = () => {
+  return createElement('style', {}, cssText);
+};
+
+export const GoBackToLinkedInContent = ({
+  id,
+  isOpen,
+  onCloseCallback,
+}: {
+  id: string;
+  isOpen: boolean;
+  onCloseCallback: () => void;
+}) => {
+  const askToOpenLinkedInTab = () => {
+    chrome.runtime.sendMessage('openLinkedInTab');
+    onCloseCallback();
+  };
+
+  return (
+    <IFramedSidePanel
+      hasCloseButton={true}
+      hasTranslateButton={false}
+      head={getIFrameStyle()}
+      isOpen={isOpen}
+      onCloseCallback={onCloseCallback}
+      id={id}
+      className="top-48 space-y-4 flex flex-col">
+      <div className="flex flex-col items-center">
+        <img src={logo} className="w-12" />
+        <ButtonPrimary onClick={askToOpenLinkedInTab}>Go Back To Linkedin</ButtonPrimary>
+      </div>
+    </IFramedSidePanel>
+  );
+};

--- a/apps/linkedin-to-notion/src/contents/go-back-to-linkedin-side-panel.tsx
+++ b/apps/linkedin-to-notion/src/contents/go-back-to-linkedin-side-panel.tsx
@@ -2,10 +2,10 @@ import cssText from 'data-text:~style.css';
 import type { PlasmoCSConfig, PlasmoGetStyle } from 'plasmo';
 import { useState } from 'react';
 
-import { LinkedInNotionSidePanelContent } from '../components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent';
+import { GoBackToLinkedInContent } from '../components/GoBackToLinkedIn/GoBackToLinkedIn';
 
 export const config: PlasmoCSConfig = {
-  matches: ['https://www.linkedin.com/in/*'],
+  matches: ['<all_urls>'],
   all_frames: false,
 };
 
@@ -16,12 +16,12 @@ export const getStyle: PlasmoGetStyle = () => {
   return style;
 };
 
-const LinkedinNotionSidePanel = () => {
-  const [isOpen, setIsOpen] = useState(true); // set-back to false before deployment
+const GoBackToLinkedInSidePanel = () => {
+  const [isOpen, setIsOpen] = useState(false); // set-back to false before deployment
 
   // Listen the icon onClick message from the background script
   chrome.runtime.onMessage.addListener((msg) => {
-    if (msg === 'toggleLinkedInNotionSidePanel') {
+    if (msg === 'toggleGoBackToLinkedInSidePanel') {
       return setIsOpen(!isOpen);
     }
 
@@ -31,12 +31,12 @@ const LinkedinNotionSidePanel = () => {
   });
 
   return (
-    <LinkedInNotionSidePanelContent
+    <GoBackToLinkedInContent
       isOpen={isOpen}
       onCloseCallback={() => setIsOpen(false)}
-      id="linkedin-to-notion-side-panel"
+      id="go-back-to-linkedin-side-panel"
     />
   );
 };
 
-export default LinkedinNotionSidePanel;
+export default GoBackToLinkedInSidePanel;


### PR DESCRIPTION
When user tries to open the extension (by clicking on its icon) on a page that's not LinkedIn, instead of the usual side panel, we display one with a call to action to open **his own profile** on LinkedIn.