### PR TITLE
🐛 fix(front) PLAS-048: Scraping Complete Check Was Too Restrictive

### DIFF
--- a/apps/linkedin-to-notion/src/contents/helpers.ts
+++ b/apps/linkedin-to-notion/src/contents/helpers.ts
@@ -4,5 +4,5 @@ export const isScrapingComplete = (values: LinkedInProfileInformation): boolean 
   if (!values) {
     return false;
   }
-  return Object.values(values).every((value) => value != null);
+  return Object.values(values).every((value) => value !== null);
 };

--- a/apps/linkedin-to-notion/src/contents/helpers.ts
+++ b/apps/linkedin-to-notion/src/contents/helpers.ts
@@ -4,5 +4,5 @@ export const isScrapingComplete = (values: LinkedInProfileInformation): boolean 
   if (!values) {
     return false;
   }
-  return Object.values(values).every((value) => value);
+  return Object.values(values).every((value) => value != null);
 };


### PR DESCRIPTION
In `helper.ts`, the `isScrapingComplete` function returned true iff all of its values were different from null, undefined or an empty string. However, we must tolerate empty strings, because on some profiles (like [this one](https://www.linkedin.com/in/genevieve-leclercq/)), pieces of data can be empty (like the job title, for instance, cf. example).