### PR TITLE
🐛 fix(design,infra) PLAS-051: From Interfaces to Types to Avoid Build Errors

### DIFF
--- a/libs/design-system/src/atoms/buttons/buttons.tsx
+++ b/libs/design-system/src/atoms/buttons/buttons.tsx
@@ -4,7 +4,7 @@ import './../../index.css';
 
 import { cn } from '../../shared/classnames';
 
-interface ButtonProps {
+type ButtonProps = {
   /**
    * Children elements
    */
@@ -27,7 +27,7 @@ interface ButtonProps {
    * A callback to detect clicks on the text (default: undefined)
    */
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
-}
+};
 
 const typeSpecificClasses = {
   primary: 'px-4 py-2 rounded-md text-5',

--- a/libs/design-system/src/atoms/titles/titles.tsx
+++ b/libs/design-system/src/atoms/titles/titles.tsx
@@ -4,7 +4,7 @@ import './../../index.css';
 
 import { cn } from '../../shared/classnames';
 
-interface TitleProps {
+type TitleProps = {
   /**
    * Children elements
    */
@@ -32,7 +32,7 @@ interface TitleProps {
    * A callback to detect clicks on the text (default: undefined)
    */
   onClick?: React.MouseEventHandler<HTMLElement>;
-}
+};
 
 const headingsDesktop = {
   h1: 'text-15 leading-14 uppercase',


### PR DESCRIPTION
Removing interfaces from the design system solved this [build problem](https://www.notion.so/bvelitchkine/Types-Not-Interfaces-e5ea5bc8f3f24c118750219d3cf2b583).