### PR TITLE
✨ feat(front, back) PLAS-52: let the user choose an eligible Notion DB and save it to storage

### DIFF
--- a/apps/linkedin-to-notion/src/background/messages/notion/providers/notion.provider.ts
+++ b/apps/linkedin-to-notion/src/background/messages/notion/providers/notion.provider.ts
@@ -1,0 +1,57 @@
+import { Client } from '@notionhq/client';
+import type { DatabaseObjectResponse, SearchResponse } from '@notionhq/client/build/src/api-endpoints';
+
+export default class NotionProvider {
+  private readonly notion: Client;
+
+  constructor(private readonly NOTION_TOKEN: string) {
+    this.notion = new Client({
+      auth: this.NOTION_TOKEN,
+    });
+  }
+
+  async getDatabases(): Promise<DatabaseObjectResponse[]> {
+    let searchResults: SearchResponse;
+    try {
+      searchResults = await this.notion.search({
+        filter: {
+          value: 'database',
+          property: 'object',
+        },
+        sort: {
+          direction: 'descending',
+          timestamp: 'last_edited_time',
+        },
+      });
+    } catch (error) {
+      console.error("NotionProvider, getDatabases, couldn't get databases:", error);
+      return [];
+    }
+
+    const mandatoryProperties = [
+      'comment',
+      'company',
+      'firstName',
+      'fullName',
+      'gender',
+      'hiringDate',
+      'jobTitle',
+      'lastName',
+      'linkedinUrl',
+      'location',
+      'status',
+    ];
+    const filteredEligibleDatabases = searchResults.results.filter((database: DatabaseObjectResponse) => {
+      const databaseProperties = Object.keys(database.properties);
+      let isEligible = true;
+      mandatoryProperties.forEach((property) => {
+        if (!databaseProperties.includes(property)) {
+          isEligible = false;
+        }
+      });
+      return isEligible;
+    }) as DatabaseObjectResponse[]; // safe casting based on the search filter
+
+    return filteredEligibleDatabases;
+  }
+}

--- a/apps/linkedin-to-notion/src/background/messages/notion/resolvers/getEligibleDatabases.ts
+++ b/apps/linkedin-to-notion/src/background/messages/notion/resolvers/getEligibleDatabases.ts
@@ -1,0 +1,12 @@
+import type { PlasmoMessaging } from '@plasmohq/messaging';
+
+import NotionProvider from '../providers/notion.provider';
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const notionService = new NotionProvider(req.body.notionToken);
+  const databases = await notionService.getDatabases();
+
+  res.send({ databases });
+};
+
+export default handler;

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/Form.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/Form.tsx
@@ -2,6 +2,7 @@ import { ButtonPrimary, SelectEntry, TextAreaEntry, TextEntry, ToggleEntry } fro
 import { useEffect, useState } from 'react';
 
 import { type LinkedInProfileInformation } from './../../contents/linkedin-profile-scraper';
+import { NotionDatabasesSelect } from './NotionDatabasesSelect';
 
 export type NotionProfileInformation = {
   /**
@@ -101,6 +102,7 @@ export const Form = ({
 
   return (
     <div className="flex flex-col space-y-3">
+      <NotionDatabasesSelect />
       {notionValues && (
         <ToggleEntry
           options={{ unchecked: 'LinkedIn', checked: 'Notion' }}

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
@@ -1,6 +1,5 @@
-import logo from 'data-base64:~assets/icon.png';
 import cssText from 'data-text:~style.css';
-import { ButtonPrimary, Heading2, IFramedSidePanel, Spinner } from 'design-system';
+import { ButtonPrimary, IFramedSidePanel, Spinner } from 'design-system';
 import { createElement, useEffect, useState } from 'react';
 
 import './../../../style.css'; // for the font to load
@@ -93,10 +92,6 @@ export const LinkedInNotionSidePanelContent = ({
       onLogoutCallback={() => logoutCallBack()}
       id={id}
       className="top-48 space-y-4 flex flex-col">
-      <div className="flex flex-col items-center">
-        <img src={logo} className="w-12" />
-        <Heading2>LinkedIn to Notion</Heading2>
-      </div>
       {isLoggedIn ? (
         linkedInProfileInformation ? (
           <Form

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/NotionDatabasesSelect.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/NotionDatabasesSelect.tsx
@@ -1,0 +1,54 @@
+import type { DatabaseObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { SelectEntry, Spinner } from 'design-system';
+import { useEffect, useState } from 'react';
+
+import { sendToBackground } from '@plasmohq/messaging';
+import { useStorage } from '@plasmohq/storage/hook';
+
+import { getDatabaseTitle } from './notionFormat.util';
+
+export const NotionDatabasesSelect = () => {
+  const [notionDatabases, setNotionDatabases] = useState<{ databases: DatabaseObjectResponse[] } | null>(null);
+  const [selectedNotionDatabase, setSelectedNotionDatabase] = useStorage<string>('selectedNotionDatabase');
+  const [notionToken] = useStorage('notionToken');
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const notionDatabasesSetter = async () => {
+      const databases = await sendToBackground({
+        name: 'notion/resolvers/getEligibleDatabases',
+        body: {
+          notionToken: notionToken.accessToken,
+        },
+      });
+      setNotionDatabases(databases);
+      setIsLoading(false);
+    };
+
+    if (notionToken?.accessToken) {
+      notionDatabasesSetter();
+    }
+  }, [notionToken]);
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (!notionDatabases?.databases?.length) {
+    return <></>;
+  }
+
+  return (
+    <SelectEntry
+      labelText="Notion databases"
+      id="notion-databases"
+      handleChange={(e) => setSelectedNotionDatabase(e.target.value)}
+      initialValue={selectedNotionDatabase}
+      options={notionDatabases.databases.map((database: DatabaseObjectResponse) => ({
+        id: database.id,
+        label: getDatabaseTitle(database),
+        value: database.id,
+      }))}
+    />
+  );
+};

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/notionFormat.util.ts
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/notionFormat.util.ts
@@ -1,0 +1,11 @@
+import type { DatabaseObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+
+export const getDatabaseTitle = (database: DatabaseObjectResponse): string => {
+  const icon = database.icon && database.icon.type === 'emoji' ? database.icon.emoji : '';
+
+  if (!database.title.length) {
+    return database.id;
+  }
+
+  return `${icon} ${database.title[0].plain_text}`.trim();
+};

--- a/monorepo.code-workspace
+++ b/monorepo.code-workspace
@@ -15,6 +15,7 @@
   ],
   "settings": {
     "cSpell.words": [
+      "notionhq",
       "plasmohq",
       "supabase"
     ]


### PR DESCRIPTION
# Context

Not much to add. See [Notion](https://www.notion.so/bvelitchkine/Fetch-Eligible-Databases-in-Dropdown-f929e250ef344f379d11062300e5a30a?pvs=4) if needed.
Sorry, I removed the secure storage. I felt like it was slowing me down. So much easier to work with the hook. Don't hesitate to let me know if it's not okay for you.

# Solution

![image](https://github.com/Bastien-and-Gauvain/monorepo/assets/79575726/c9b64c28-892f-4d23-b377-a23f7ed62192)
![image](https://github.com/Bastien-and-Gauvain/monorepo/assets/79575726/26a3e0ac-b19f-4f60-9b74-943095f65f01)

# Priority

High