### PR TITLE
🎨 impr(front) PLAS-059: No 'Refresh' button on Notion values

### DIFF
--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/Form.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/Form.tsx
@@ -308,7 +308,7 @@ export const Form = ({
                 Save
               </ButtonPrimary>
             )}
-            <ButtonPrimary onClick={onReload}>🔄</ButtonPrimary>
+            {!displayNotionValues && <ButtonPrimary onClick={onReload}>🔄</ButtonPrimary>}
           </div>
         </>
       )}


### PR DESCRIPTION
# Context

There's a "refresh" button to re-scrape data from the LinkedIn profile page and fill the extension's fields with them. We don't want to display this button on a profile that's already in db when we're looking at Notion values.

# Solution
![noRefreshOnNotionValues](https://github.com/Bastien-and-Gauvain/monorepo/assets/45038783/f11c47e7-9dd4-4dd5-8e04-3e2f03160afc)

# Priority

Low
