### PR TITLE
🐛 fix(front,back) PLAS-88: cant-re-open-extension

### DIFF
--- a/apps/linkedin-to-notion/src/background/shared.utils.ts
+++ b/apps/linkedin-to-notion/src/background/shared.utils.ts
@@ -21,3 +21,24 @@ export const getLinkedinSlug = (linkedinUrl: string): string | null => {
   const match = linkedinUrl.match(regex);
   return match ? match[0] : null;
 };
+
+/**
+ * A function that retries a request a given number of times
+ * @param fn The function to retry
+ * @param retries The number of retries
+ * @param delay The delay between each retry
+ * @returns The result of the function
+ */
+export const retryRequest = async <T>(fn: () => Promise<T>, retries = 3, delay = 1000): Promise<T> => {
+  let delayIncrement = 1;
+  try {
+    return await fn();
+  } catch (error) {
+    if (retries === 0) {
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delay * delayIncrement));
+    delayIncrement++;
+    return await retryRequest(fn, retries - 1, delay);
+  }
+};

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/Form.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/Form.tsx
@@ -41,7 +41,7 @@ export const Form = ({
   const [status, setStatus] = useState<NotionProfileStatus>('NOT_CONTACTED');
   const [gender, setGender] = useState<NotionProfileGender>('');
   const [comment, setComment] = useState<string>('');
-  const linkedinUrl = window.location.href.match(/https:\/\/[a-z]{2,4}\.linkedin\.com\/in\/[^/]+\//gim)[0];
+  const linkedinUrl = window.location.href.match(/https:\/\/[a-z]{2,4}\.linkedin\.com\/in\/[^/]+\//gim)?.[0];
 
   // To handle the toggle switch
   const [displayNotionValues, setDisplayNotionValues] = useState<boolean>(false);
@@ -249,6 +249,11 @@ export const Form = ({
 
   if (isNotionLoading) {
     return <FullScreenLoader />;
+  }
+
+  // If we're not on a linkedin profile, we don't bother loading the form and avoid potential errors
+  if (!linkedinUrl) {
+    return <></>;
   }
 
   return (

--- a/apps/linkedin-to-notion/src/contents/linkedin-notion-side-panel.tsx
+++ b/apps/linkedin-to-notion/src/contents/linkedin-notion-side-panel.tsx
@@ -1,7 +1,7 @@
 import type { Provider, User } from '@supabase/supabase-js';
 import cssText from 'data-text:~style.css';
 import type { PlasmoCSConfig, PlasmoGetStyle } from 'plasmo';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { sendToBackground } from '@plasmohq/messaging';
 import { useStorage } from '@plasmohq/storage/hook';
@@ -23,12 +23,15 @@ export const getStyle: PlasmoGetStyle = () => {
 };
 
 const LinkedinNotionSidePanel = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useStorage('linkedInNotionSidePanelIsOpen', false);
   const [user, setUser] = useStorage<User>('user');
+  const [selectedNotionDatabase, setSelectedNotionDatabase] = useStorage<string>('selectedNotionDatabase');
   const [notionToken, setNotionToken] = useStorage<{
     refreshToken: string;
     accessToken: string;
   }>('notionToken');
+
+  selectedNotionDatabase; // to remove ts error
 
   useEffect(() => {
     async function init() {
@@ -90,7 +93,12 @@ const LinkedinNotionSidePanel = () => {
       isOpen={isOpen}
       isLoggedIn={!!user?.id}
       loginCallback={() => handleOAuthLogin('notion')}
-      logoutCallBack={() => [supabase.auth.signOut(), setUser(null)]}
+      logoutCallBack={() => [
+        supabase.auth.signOut(),
+        setUser(null),
+        setSelectedNotionDatabase(''),
+        setNotionToken(null),
+      ]}
       onCloseCallback={() => setIsOpen(false)}
       id="linkedin-to-notion-side-panel"
     />

--- a/libs/design-system/src/atoms/inputs/selectInputs.tsx
+++ b/libs/design-system/src/atoms/inputs/selectInputs.tsx
@@ -86,7 +86,7 @@ export const SelectInput = ({ id, required = false, value, className, handleChan
         <ChevronDownIcon className="plasmo-h-4 plasmo-w-4" />
       </div>
       {isOpen && (
-        <ul className="plasmo-absolute plasmo-left-0 plasmo-w-full plasmo-mt-1 plasmo-overflow-auto plasmo-bg-white plasmo-border plasmo-border-grey-transparent plasmo-rounded-md plasmo-shadow-lg plasmo-max-h-60 plasmo-focus:outline-none">
+        <ul className="plasmo-absolute plasmo-left-0 plasmo-w-full plasmo-mt-1 plasmo-overflow-auto plasmo-bg-white plasmo-border plasmo-border-grey-transparent plasmo-rounded-md plasmo-shadow-lg plasmo-max-h-60 plasmo-focus:outline-none plasmo-z-40">
           {options.map(({ id, value, label }) => (
             <li
               key={id}


### PR DESCRIPTION
# Context

I fixed a couple of things here:
1. Open is now handled using storage which allows us to autonatically reopen side panel after login or when user opens a profile in a new tab
2. Form creates bugs if open when not on a profile page which led to the iframe/app to crash. It's now prevented
3. Minor fix on select (I honestly think we shouldn't have bothered with a custom picker here, sorry)
4. Notion might be slow to detect a new DB after using the template login so I added a retry on. And another retry on the find profile as well

# Priority

Very High
