### PR TITLE
✨ feat(back): Save User's LinkedIn Info in Supabase

### DIFF
--- a/apps/linkedin-to-notion/src/background/messages/users/resolvers/updateUserLinkedInProfileInfo.ts
+++ b/apps/linkedin-to-notion/src/background/messages/users/resolvers/updateUserLinkedInProfileInfo.ts
@@ -1,0 +1,12 @@
+import type { PlasmoMessaging } from '@plasmohq/messaging';
+
+import { UserService } from '../services/user.service';
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  const userService = new UserService();
+  const user = await userService.updateUserLinkedInProfileInfo(req.body.id, req.body.userLinkedInProfileInfo);
+
+  res.send(user);
+};
+
+export default handler;

--- a/apps/linkedin-to-notion/src/background/messages/users/services/user.service.ts
+++ b/apps/linkedin-to-notion/src/background/messages/users/services/user.service.ts
@@ -1,11 +1,34 @@
 import { supabase } from '~core/supabase';
 import type { Tables } from '~src/background/types/supabase';
+import type { LinkedInProfileInformation } from '~src/contents/scrapers/linkedin-profile-scraper';
 
 export enum OnboardingStatus {
   CONNECTED_TO_NOTION = 'CONNECTED_TO_NOTION',
   FIRST_PROFILE_SAVED = 'FIRST_PROFILE_SAVED',
   EXTENSION_PINNED = 'EXTENSION_PINNED',
 }
+
+export type LinkedInProfileInformationForSupabase = {
+  first_name: string;
+  last_name: string;
+  job_title: string;
+  company_name: string;
+  location: string;
+};
+
+const transformLinkedInProfileInfoForSupabase = (
+  userLinkedInProfileInfo: LinkedInProfileInformation
+): LinkedInProfileInformationForSupabase => {
+  const { name, jobTitle, company, location } = userLinkedInProfileInfo;
+
+  return {
+    first_name: name.firstName,
+    last_name: name.lastName,
+    job_title: jobTitle,
+    company_name: company,
+    location: location,
+  };
+};
 
 export class UserService {
   constructor() {}
@@ -65,6 +88,32 @@ export class UserService {
 
     if (error) {
       throw new Error(`updateOnboardingStatus: couldn't update user ${id} - ${JSON.stringify(error)}`);
+    }
+
+    return user[0];
+  }
+
+  /**
+   * Update the onboarding status of a user
+   * @param id User ID
+   * @param onboardingStatus Onboarding status
+   * @returns User
+   */
+  async updateUserLinkedInProfileInfo(
+    id: string,
+    userLinkedInProfileInfo: LinkedInProfileInformation
+  ): Promise<Tables<'users'>> {
+    const userLinkedInProfileInfoForSupabase = transformLinkedInProfileInfoForSupabase(userLinkedInProfileInfo);
+    const { data: user, error } = await supabase
+      .from('users')
+      .update(userLinkedInProfileInfoForSupabase)
+      .eq('id', id)
+      .select('*');
+
+    if (error) {
+      throw new Error(
+        `updateUserLinkedInProfileInfo: couldn't update linkedin profile info of user ${id} - ${JSON.stringify(error)}`
+      );
     }
 
     return user[0];

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
@@ -2,6 +2,11 @@ import cssText from 'data-text:~style.css';
 import { ButtonPrimary, IFramedSidePanel } from 'design-system';
 import { createElement, useEffect, useState } from 'react';
 
+import { sendToBackground } from '@plasmohq/messaging';
+import { useStorage } from '@plasmohq/storage/hook';
+
+import type { Tables } from '~src/background/types/supabase';
+
 import {
   getLinkedInProfileInformation,
   type LinkedInProfileInformation,
@@ -30,6 +35,7 @@ export const LinkedInNotionSidePanelContent = ({
 }) => {
   const [linkedInProfileInformation, setLinkedInProfileInformation] = useState<LinkedInProfileInformation | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [user] = useStorage<Tables<'users'>>('user');
 
   const setLinkedInValues = async () => {
     setIsLoading(true);
@@ -38,9 +44,25 @@ export const LinkedInNotionSidePanelContent = ({
     setIsLoading(false);
   };
 
+  const sendUserLinkedInProfileInfoToBackground = async (scrapingResults: LinkedInProfileInformation) => {
+    await sendToBackground({
+      name: 'users/resolvers/updateUserLinkedInProfileInfo',
+      body: {
+        id: user.id,
+        userLinkedInProfileInfo: scrapingResults,
+      },
+    });
+  };
+
   useEffect(() => {
     setLinkedInValues();
   }, []);
+
+  useEffect(() => {
+    if (!!user && linkedInProfileInformation?.linkedInURL.match(/linkedin\.com\/in\/me/)) {
+      sendUserLinkedInProfileInfoToBackground(linkedInProfileInformation);
+    }
+  }, [linkedInProfileInformation, user]);
 
   // Listen the icon onClick message from the background script
   chrome.runtime.onMessage.addListener((msg) => {

--- a/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
+++ b/apps/linkedin-to-notion/src/components/LinkedInNotionSidePanel/LinkedInNotionSidePanelContent.tsx
@@ -59,7 +59,7 @@ export const LinkedInNotionSidePanelContent = ({
   }, []);
 
   useEffect(() => {
-    if (!!user && linkedInProfileInformation?.linkedInURL.match(/linkedin\.com\/in\/me/)) {
+    if (user?.id && linkedInProfileInformation?.linkedInURL.match(/linkedin\.com\/in\/me/)) {
       sendUserLinkedInProfileInfoToBackground(linkedInProfileInformation);
     }
   }, [linkedInProfileInformation, user]);


### PR DESCRIPTION
# Context

We want to better know our users. In that respect, we want to save their LI profile info whenever they visit their own LI profile page. More details in #75 

# Solution

Everything related to labor illusion was discarded because it's become useless thanks to Gauvain's implementation of the onboarding flow.