### PR TITLE
✨ feat(front, back): First Profile Saved is Special 👀

### DIFF
--- a/apps/linkedin-to-notion/src/background/messages/notion/providers/notion.provider.ts
+++ b/apps/linkedin-to-notion/src/background/messages/notion/providers/notion.provider.ts
@@ -1,5 +1,7 @@
 import { Client } from '@notionhq/client';
 import type {
+  AppendBlockChildrenResponse,
+  BlockObjectRequest,
   CreatePageResponse,
   DatabaseObjectResponse,
   SearchResponse,
@@ -100,6 +102,35 @@ export class NotionProvider {
       throw new Error(
         JSON.stringify({
           error: "NotionProvider, createPageInDatabase, couldn't create page",
+          message: error,
+        })
+      );
+    }
+
+    return response;
+  }
+
+  /**
+   * Add content blocks to a page
+   * @param pageId The id of the page to update
+   * @param blocks The blocks to add to the page
+   * @returns the response from the Notion API
+   */
+  async appendChildrenBlocksToPage(
+    pageId: string,
+    blocks: BlockObjectRequest[]
+  ): Promise<AppendBlockChildrenResponse | ErrorResponse> {
+    let response: AppendBlockChildrenResponse;
+    try {
+      response = await this.notion.blocks.children.append({
+        block_id: pageId,
+        children: blocks,
+      });
+    } catch (error) {
+      console.error("NotionProvider, addPageBlocks, couldn't add content blocks to the page:", error);
+      throw new Error(
+        JSON.stringify({
+          error: "NotionProvider, addPageBlocks, couldn't add content blocks to the page",
           message: error,
         })
       );

--- a/apps/linkedin-to-notion/src/background/messages/notion/resolvers/createOnboardingProfileInDatabase.ts
+++ b/apps/linkedin-to-notion/src/background/messages/notion/resolvers/createOnboardingProfileInDatabase.ts
@@ -1,0 +1,101 @@
+import type {
+  AppendBlockChildrenResponse,
+  BlockObjectRequest,
+  CreatePageResponse,
+  PageObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+
+import type { PlasmoMessaging } from '@plasmohq/messaging';
+
+import type { ErrorResponse, NotionProfileInformation } from '../notion.type';
+import { NotionProvider } from '../providers/notion.provider';
+
+enum OnboardingContent {
+  CALLOUT_TEXT = 'Bastien, congratulations! These 1-click exports are going to save a lot of your time each week. We wanted to thank you, so here’s a quick vid to show you how to get the most out of the extension 👇',
+  CALLOUT_ICON = '✨',
+  VIDEO_URL = 'https://www.youtube.com/watch?v=ngwr44N6GGI',
+}
+
+export type OnboardingPageObjectResponse = AppendBlockChildrenResponse & {
+  id: string;
+  url: string;
+};
+
+const handler: PlasmoMessaging.MessageHandler<
+  {
+    notionToken: string;
+    databaseId: string;
+    linkedInProfileInformation: NotionProfileInformation;
+  },
+  OnboardingPageObjectResponse | ErrorResponse
+> = async (req, res) => {
+  const { notionToken, databaseId, linkedInProfileInformation } = req.body;
+  const notionService = new NotionProvider(notionToken);
+  const pageResponse = await notionService.createPageInDatabase(databaseId, linkedInProfileInformation);
+
+  if ((pageResponse as ErrorResponse).error) {
+    res.send(pageResponse as ErrorResponse);
+    return;
+  }
+
+  // If we move along, it means that the pageResponse is a CreatePageResponse
+  const blocks: BlockObjectRequest[] = [
+    {
+      type: 'callout',
+      callout: {
+        rich_text: [
+          {
+            type: 'text',
+            text: {
+              content: OnboardingContent.CALLOUT_TEXT,
+              link: null,
+            },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: 'default',
+            },
+          },
+        ],
+        icon: {
+          type: 'emoji',
+          emoji: OnboardingContent.CALLOUT_ICON,
+        },
+        color: 'default',
+      },
+    },
+    {
+      type: 'video',
+      video: {
+        caption: [],
+        type: 'external',
+        external: {
+          url: OnboardingContent.VIDEO_URL,
+        },
+      },
+    },
+    // {
+    //   type: 'embed',
+    //   embed: {
+    //     url: OnboardingContent.VIDEO_URL,
+    //   },
+    // },
+  ];
+  const response = await notionService.appendChildrenBlocksToPage((pageResponse as CreatePageResponse).id, blocks);
+  if ((response as ErrorResponse).error) {
+    res.send(response as ErrorResponse);
+    return;
+  }
+  const result = {
+    ...response,
+    id: (pageResponse as PageObjectResponse).id,
+    url: (pageResponse as PageObjectResponse).url,
+  };
+  res.send(result);
+  return;
+};
+
+export default handler;

--- a/apps/linkedin-to-notion/src/background/messages/notion/resolvers/createOnboardingProfileInDatabase.ts
+++ b/apps/linkedin-to-notion/src/background/messages/notion/resolvers/createOnboardingProfileInDatabase.ts
@@ -77,12 +77,6 @@ const handler: PlasmoMessaging.MessageHandler<
         },
       },
     },
-    // {
-    //   type: 'embed',
-    //   embed: {
-    //     url: OnboardingContent.VIDEO_URL,
-    //   },
-    // },
   ];
   const response = await notionService.appendChildrenBlocksToPage((pageResponse as CreatePageResponse).id, blocks);
   if ((response as ErrorResponse).error) {
@@ -95,6 +89,11 @@ const handler: PlasmoMessaging.MessageHandler<
     url: (pageResponse as PageObjectResponse).url,
   };
   res.send(result);
+
+  // Open a new tab with the newly created page
+  const cleanDatabaseId = databaseId.replaceAll('-', '');
+  const cleanPageId = result.id.replaceAll('-', '');
+  chrome.tabs.create({ url: `https://www.notion.so/${cleanDatabaseId}?p=${cleanPageId}&pm=s`, active: true });
   return;
 };
 


### PR DESCRIPTION
# Context

As part of the onboarding, we want users to save a first profile and look at what the results look like. This is the crux of the matter of the onboarding - the most wanted "aha moment". That why we wanted:
1. A special first profile page with content blocks inside to thank, congratulate and educate users #77 
2. A redirection so that the user can't miss the profile he just saved #79 

# Warning

Proper onboarding material still has to be shot to show:
- [ ] How to edit a profile before saving it
- [ ] How to update a profile that's already saved in the db
- [ ] How to switch between databases
- [ ] How to add/remove databases shared with the extension

Once the video(s) are shot, we'll have to upload it on Youtube and update the code accordingly.